### PR TITLE
Add legal notice for using mockito-kotlin

### DIFF
--- a/LEGAL_NOTICE.md
+++ b/LEGAL_NOTICE.md
@@ -69,6 +69,35 @@ This software contains the following license and notice below:
 
 - - -
 
+The following software may depends on in this application: **mockito-kotlin** from [https://github.com/nhaarman/mockito-kotlin](https://github.com/nhaarman/mockito-kotlin). 
+
+This software contains the following license and notice below:
+
+> The MIT License
+> 
+> Copyright (c) 2016 Niek Haarman  
+> Copyright (c) 2007 Mockito contributors
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
+
+- - -
+
 The following software may depends on in this application: **junit5** from [https://junit.org/junit5/](https://junit.org/junit5/). 
 
 This software contains the following license and notice below:


### PR DESCRIPTION
I added `mockit-kotlin` at #6 . 